### PR TITLE
Add `haystacks:clear` and `haystacks:forget` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,18 @@ $schedule->command('model:prune', [
 ])->daily();
 ```
 
+## Deleting A Specific Haystack
+If a haystack was created by mistake, and you would like to delete it without directly accessing the database, you may use the `haystacks:forget` command. The `haystacks:forget` command accepts the ID of the haystack as its only argument:
+```bash
+php artisan haystacks:forget <id>
+```
+
+## Clearing All Haystacks
+If you would like to clear all haystacks from the database, you may use the `haystacks:clear` command. The `haystacks:clear` command accepts no arguments:
+```bash
+php artisan haystacks:clear
+```
+
 ## Support Haystack's Development
 While I never expect anything, if you would like to support my work, you can donate to my Ko-Fi page by simply buying me a coffee or two! https://ko-fi.com/sammyjo20
 

--- a/src/Console/Commands/HaystacksClear.php
+++ b/src/Console/Commands/HaystacksClear.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sammyjo20\LaravelHaystack\Console\Commands;
+
+use Illuminate\Console\Command;
+use Sammyjo20\LaravelHaystack\Models\Haystack;
+
+class HaystacksClear extends Command
+{
+    public $signature = 'haystacks:clear';
+
+    public $description = 'Delete all haystacks.';
+
+    public function handle(): int
+    {
+        $count = Haystack::query()->delete();
+
+        $this->info("Cleared $count haystacks'");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/HaystacksForget.php
+++ b/src/Console/Commands/HaystacksForget.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sammyjo20\LaravelHaystack\Console\Commands;
+
+use Illuminate\Console\Command;
+use Sammyjo20\LaravelHaystack\Models\Haystack;
+
+class HaystacksForget extends Command
+{
+    public $signature = 'haystacks:forget {id}';
+
+    public $description = 'Delete a haystack by ID.';
+
+    public function handle(): int
+    {
+        $haystack = Haystack::find($this->argument('id'));
+
+        if (! $haystack) {
+            $this->error('No haystack matches the given ID.');
+            return self::FAILURE;
+        }
+
+        $haystack->delete();
+        $this->info('Haystack deleted successfully!');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/LaravelHaystackServiceProvider.php
+++ b/src/LaravelHaystackServiceProvider.php
@@ -4,6 +4,8 @@ namespace Sammyjo20\LaravelHaystack;
 
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Queue\Events\JobFailed;
+use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksClear;
+use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksForget;
 use Spatie\LaravelPackageTools\Package;
 use Illuminate\Queue\Events\JobProcessed;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -32,7 +34,9 @@ class LaravelHaystackServiceProvider extends PackageServiceProvider
                 'create_haystack_bales_table',
                 'create_haystack_data_table',
             ])
-            ->hasCommand(ResumeHaystacks::class);
+            ->hasCommand(ResumeHaystacks::class)
+            ->hasCommand(HaystacksForget::class)
+            ->hasCommand(HaystacksClear::class);
     }
 
     /**

--- a/tests/Feature/CommandsTest.php
+++ b/tests/Feature/CommandsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Sammyjo20\LaravelHaystack\Models\Haystack;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\NameJob;
+use function Pest\Laravel\artisan;
+
+it('can delete a haystack by ID', function () {
+    $haystack = Haystack::build()
+        ->addJob(new NameJob('Sam'))
+        ->addJob(new NameJob('Steve'))
+        ->create();
+
+    $this->assertDatabaseHas('haystacks', ['id' => $haystack->id]);
+    $this->assertDatabaseHas('haystack_bales', ['haystack_id' => $haystack->id]);
+
+    artisan('haystacks:forget', ['id' => $haystack->id]);
+
+    $this->assertDatabaseMissing('haystacks', ['id' => $haystack->id]);
+    $this->assertDatabaseMissing('haystack_bales', ['haystack_id' => $haystack->id]);
+});
+
+it('can clear all haystacks', function () {
+    Collection::times(10, fn () => Haystack::build()
+        ->addJob(new NameJob('Sam'))
+        ->addJob(new NameJob('Steve'))
+        ->create());
+
+    $this->assertDatabaseCount('haystacks', 10);
+    $this->assertDatabaseCount('haystack_bales', 20);
+
+    artisan('haystacks:clear');
+
+    $this->assertDatabaseCount('haystacks', 0);
+    $this->assertDatabaseCount('haystack_bales', 0);
+});


### PR DESCRIPTION
Added new commands to forget and clear haystacks. 
* `haystacks:forget {id}`: This command will delete a specific haystack based on the provided id.
* `haystacks:clear`: This command will clear all the haystacks on the database

The main use case would be debugging when using the package, if for some reason a haystack was created and is no longer needed it can be deleted with a simple artisan command instead of having to go to the database and deleting it from there