### PR TITLE
Fix | Fixed matrix testing for older versions of Laravel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: run-tests
 
 on:
   push:
@@ -9,41 +9,43 @@ on:
       - '*'
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1 ]
-        laravel: [ ^8.0, ^9.0 ]
-        dependency-version: [ prefer-stable ]
+        os: [ubuntu-latest, windows-latest]
+        php: [8.1]
+        laravel: [8.*, 9.*]
+        stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: ^8.0
-            testbench: ^6.0
-          - laravel: ^9.0
-            testbench: ^7.0
+          - laravel: 8.*
+            testbench: ^6.24
+          - laravel: 9.*
+            testbench: 7.*
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Install composer dependencies
+      - name: Setup problem matchers
         run: |
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: composer test
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "jessarcher/laravel-castable-data-transfer-object": "^2.2",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.24 || ^7.7",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.2",
         "spatie/laravel-ray": "^1.26"


### PR DESCRIPTION
This simply changes the test workflow so it can properly test across multiple versions of PHP, Laravel and across Windows and Ubuntu.