### PR TITLE
Feature | Models on Haystacks

### DIFF
--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -106,6 +106,13 @@ class HaystackBuilder
     protected Collection $initialData;
 
     /**
+     * Closure to execute before saving
+     *
+     * @var Closure|null
+     */
+    protected ?Closure $beforeSave = null;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -468,6 +475,7 @@ class HaystackBuilder
         $haystack->on_paused = $this->onPaused;
         $haystack->middleware = $this->globalMiddleware;
         $haystack->options = $this->options;
+        $haystack = tap($haystack, $this->beforeSave);
         $haystack->save();
 
         // We'll bulk insert the jobs and the data for efficient querying.
@@ -585,5 +593,18 @@ class HaystackBuilder
     public function getGlobalMiddleware(): ?Closure
     {
         return $this->globalMiddleware;
+    }
+
+    /**
+     * Specify a closure to run before saving the Haystack
+     *
+     * @param Closure $closure
+     * @return $this
+     */
+    public function beforeSave(Closure $closure): static
+    {
+        $this->beforeSave = $closure;
+
+        return $this;
     }
 }

--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -7,18 +7,18 @@ namespace Sammyjo20\LaravelHaystack\Builders;
 use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
-use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
-use Sammyjo20\LaravelHaystack\Exceptions\HaystackModelExists;
+use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Data\PendingData;
 use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
+use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
 use Sammyjo20\LaravelHaystack\Helpers\ClosureHelper;
 use Sammyjo20\LaravelHaystack\Helpers\DataValidator;
 use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
 use Sammyjo20\LaravelHaystack\Data\PendingHaystackBale;
-use Sammyjo20\LaravelHaystack\Models\Haystack;
+use Sammyjo20\LaravelHaystack\Exceptions\HaystackModelExists;
 
 class HaystackBuilder
 {
@@ -388,14 +388,15 @@ class HaystackBuilder
     /**
      * Store a model to be shared across all haystack jobs.
      *
-     * @param Model $model
-     * @param string|null $key
+     * @param  Model  $model
+     * @param  string|null  $key
      * @return $this
+     *
      * @throws HaystackModelExists
      */
     public function withModel(Model $model, string $key = null): static
     {
-        $key = 'model:' . ($key ?? $model::class);
+        $key = 'model:'.($key ?? $model::class);
 
         if ($this->initialData->has($key)) {
             throw new HaystackModelExists($key);

--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -640,8 +640,8 @@ class HaystackBuilder
     /**
      * Set an option on the Haystack Options.
      *
-     * @param string $option
-     * @param mixed $value
+     * @param  string  $option
+     * @param  mixed  $value
      * @return $this
      */
     public function setOption(string $option, mixed $value): static

--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -6,14 +6,14 @@ namespace Sammyjo20\LaravelHaystack\Builders;
 
 use Closure;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Conditionable;
-use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Data\PendingData;
 use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
+use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
 use Sammyjo20\LaravelHaystack\Helpers\ClosureHelper;
 use Sammyjo20\LaravelHaystack\Helpers\DataValidator;
 use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
@@ -387,13 +387,13 @@ class HaystackBuilder
     /**
      * Store a model to be shared across all haystack jobs.
      *
-     * @param string $key
-     * @param Model $model
+     * @param  string  $key
+     * @param  Model  $model
      * @return $this
      */
     public function withModel(string $key, Model $model): static
     {
-        $key = 'model:' . $key;
+        $key = 'model:'.$key;
 
         $this->initialData->put($key, new PendingData($key, $model, SerializedModel::class));
 
@@ -620,7 +620,7 @@ class HaystackBuilder
     /**
      * Specify a closure to run before saving the Haystack
      *
-     * @param Closure $closure
+     * @param  Closure  $closure
      * @return $this
      */
     public function beforeSave(Closure $closure): static

--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace Sammyjo20\LaravelHaystack\Builders;
 
 use Closure;
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Traits\Conditionable;
-use Sammyjo20\LaravelHaystack\Models\Haystack;
+use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
+use Sammyjo20\LaravelHaystack\Exceptions\HaystackModelExists;
 use Sammyjo20\LaravelHaystack\Data\PendingData;
 use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
-use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
 use Sammyjo20\LaravelHaystack\Helpers\ClosureHelper;
 use Sammyjo20\LaravelHaystack\Helpers\DataValidator;
 use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
 use Sammyjo20\LaravelHaystack\Data\PendingHaystackBale;
+use Sammyjo20\LaravelHaystack\Models\Haystack;
 
 class HaystackBuilder
 {
@@ -387,13 +388,18 @@ class HaystackBuilder
     /**
      * Store a model to be shared across all haystack jobs.
      *
-     * @param  string  $key
-     * @param  Model  $model
+     * @param Model $model
+     * @param string|null $key
      * @return $this
+     * @throws HaystackModelExists
      */
-    public function withModel(string $key, Model $model): static
+    public function withModel(Model $model, string $key = null): static
     {
-        $key = 'model:'.$key;
+        $key = 'model:' . ($key ?? $model::class);
+
+        if ($this->initialData->has($key)) {
+            throw new HaystackModelExists($key);
+        }
 
         $this->initialData->put($key, new PendingData($key, $model, SerializedModel::class));
 

--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -636,4 +636,18 @@ class HaystackBuilder
 
         return $this;
     }
+
+    /**
+     * Set an option on the Haystack Options.
+     *
+     * @param string $option
+     * @param mixed $value
+     * @return $this
+     */
+    public function setOption(string $option, mixed $value): static
+    {
+        $this->options->$option = $value;
+
+        return $this;
+    }
 }

--- a/src/Casts/SerializedModel.php
+++ b/src/Casts/SerializedModel.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Sammyjo20\LaravelHaystack\Casts;
 
-use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Sammyjo20\LaravelHaystack\Data\SerializedModel as SerializedModelData;
 
 class SerializedModel implements CastsAttributes

--- a/src/Casts/SerializedModel.php
+++ b/src/Casts/SerializedModel.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sammyjo20\LaravelHaystack\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+use Sammyjo20\LaravelHaystack\Data\SerializedModel as SerializedModelData;
+
+class SerializedModel implements CastsAttributes
+{
+    /**
+     * Unserialize a job.
+     *
+     * @param $model
+     * @param  string  $key
+     * @param $value
+     * @param  array  $attributes
+     * @return mixed|null
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return isset($value) ? unserialize($value, ['allowed_classes' => true])->model : null;
+    }
+
+    /**
+     * Serialize a model.
+     *
+     * @param $model
+     * @param  string  $key
+     * @param $value
+     * @param  array  $attributes
+     * @return mixed|string|null
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if (blank($value)) {
+            return null;
+        }
+
+        if (! $value instanceof Model) {
+            throw new InvalidArgumentException('The provided value must be a model.');
+        }
+
+        return serialize(new SerializedModelData($value));
+    }
+}

--- a/src/Concerns/ManagesBales.php
+++ b/src/Concerns/ManagesBales.php
@@ -330,13 +330,30 @@ trait ManagesBales
     }
 
     /**
+     * Retrieve a shared model
+     *
+     * @param string $key
+     * @param mixed|null $default
+     * @return mixed
+     */
+    public function getModel(string $key, mixed $default = null): mixed
+    {
+        return $this->getData('model:' . $key, $default);
+    }
+
+    /**
      * Retrieve all the data from the Haystack.
      *
+     * @param bool $includeModels
      * @return Collection
      */
-    public function allData(): Collection
+    public function allData(bool $includeModels = false): Collection
     {
-        return $this->data()->orderBy('id')->get()->mapWithKeys(function ($value, $key) {
+        $data = $this->data()
+            ->when($includeModels === false, fn ($query) => $query->where('key', 'NOT LIKE', 'model:%'))
+            ->orderBy('id')->get();
+
+        return $data->mapWithKeys(function ($value, $key) {
             return [$value->key => $value->value];
         });
     }

--- a/src/Concerns/ManagesBales.php
+++ b/src/Concerns/ManagesBales.php
@@ -332,19 +332,19 @@ trait ManagesBales
     /**
      * Retrieve a shared model
      *
-     * @param string $key
-     * @param mixed|null $default
+     * @param  string  $key
+     * @param  mixed|null  $default
      * @return mixed
      */
     public function getModel(string $key, mixed $default = null): mixed
     {
-        return $this->getData('model:' . $key, $default);
+        return $this->getData('model:'.$key, $default);
     }
 
     /**
      * Retrieve all the data from the Haystack.
      *
-     * @param bool $includeModels
+     * @param  bool  $includeModels
      * @return Collection
      */
     public function allData(bool $includeModels = false): Collection

--- a/src/Concerns/Stackable.php
+++ b/src/Concerns/Stackable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sammyjo20\LaravelHaystack\Concerns;
 
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Enums\FinishStatus;
@@ -235,6 +236,18 @@ trait Stackable
     public function getHaystackData(string $key, mixed $default = null): mixed
     {
         return $this->haystack->getData($key, $default);
+    }
+
+    /**
+     * Get a shared model
+     *
+     * @param string $key
+     * @param mixed|null $default
+     * @return Model|null
+     */
+    public function getHaystackModel(string $key, mixed $default = null): ?Model
+    {
+        return $this->haystack->getModel($key, $default);
     }
 
     /**

--- a/src/Concerns/Stackable.php
+++ b/src/Concerns/Stackable.php
@@ -241,8 +241,8 @@ trait Stackable
     /**
      * Get a shared model
      *
-     * @param string $model
-     * @param mixed|null $default
+     * @param  string  $model
+     * @param  mixed|null  $default
      * @return Model|null
      */
     public function getHaystackModel(string $model, mixed $default = null): ?Model

--- a/src/Concerns/Stackable.php
+++ b/src/Concerns/Stackable.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Sammyjo20\LaravelHaystack\Concerns;
 
 use Carbon\CarbonInterface;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Enums\FinishStatus;
 use Sammyjo20\LaravelHaystack\Models\HaystackBale;
@@ -241,8 +241,8 @@ trait Stackable
     /**
      * Get a shared model
      *
-     * @param string $key
-     * @param mixed|null $default
+     * @param  string  $key
+     * @param  mixed|null  $default
      * @return Model|null
      */
     public function getHaystackModel(string $key, mixed $default = null): ?Model

--- a/src/Concerns/Stackable.php
+++ b/src/Concerns/Stackable.php
@@ -7,10 +7,10 @@ namespace Sammyjo20\LaravelHaystack\Concerns;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Enums\FinishStatus;
 use Sammyjo20\LaravelHaystack\Models\HaystackBale;
+use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Helpers\CarbonHelper;
 use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
 use Sammyjo20\LaravelHaystack\Tests\Exceptions\StackableException;
@@ -297,8 +297,8 @@ trait Stackable
     /**
      * Retrieve a haystack option
      *
-     * @param string $option
-     * @param mixed|null $default
+     * @param  string  $option
+     * @param  mixed|null  $default
      * @return mixed
      */
     public function getHaystackOption(string $option, mixed $default = null): mixed

--- a/src/Concerns/Stackable.php
+++ b/src/Concerns/Stackable.php
@@ -7,6 +7,7 @@ namespace Sammyjo20\LaravelHaystack\Concerns;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Enums\FinishStatus;
 use Sammyjo20\LaravelHaystack\Models\HaystackBale;
@@ -281,5 +282,27 @@ trait Stackable
         $this->haystackBaleAttempts = $attempts;
 
         return $this;
+    }
+
+    /**
+     * Get the options on the Haystack
+     *
+     * @return HaystackOptions
+     */
+    public function getHaystackOptions(): HaystackOptions
+    {
+        return $this->haystack->options;
+    }
+
+    /**
+     * Retrieve a haystack option
+     *
+     * @param string $option
+     * @param mixed|null $default
+     * @return mixed
+     */
+    public function getHaystackOption(string $option, mixed $default = null): mixed
+    {
+        return $this->haystack->options->$option ?? $default;
     }
 }

--- a/src/Concerns/Stackable.php
+++ b/src/Concerns/Stackable.php
@@ -241,13 +241,13 @@ trait Stackable
     /**
      * Get a shared model
      *
-     * @param  string  $key
-     * @param  mixed|null  $default
+     * @param string $model
+     * @param mixed|null $default
      * @return Model|null
      */
-    public function getHaystackModel(string $key, mixed $default = null): ?Model
+    public function getHaystackModel(string $model, mixed $default = null): ?Model
     {
-        return $this->haystack->getModel($key, $default);
+        return $this->haystack->getModel($model, $default);
     }
 
     /**

--- a/src/Data/HaystackOptions.php
+++ b/src/Data/HaystackOptions.php
@@ -19,4 +19,16 @@ class HaystackOptions
      * @var bool
      */
     public bool $allowFailures = false;
+
+    /**
+     * Allow additional properties to be added to Haystack options.
+     *
+     * @param string $name
+     * @param $value
+     * @return void
+     */
+    public function __set(string $name, $value): void
+    {
+        $this->$name = $value;
+    }
 }

--- a/src/Data/HaystackOptions.php
+++ b/src/Data/HaystackOptions.php
@@ -23,7 +23,7 @@ class HaystackOptions
     /**
      * Allow additional properties to be added to Haystack options.
      *
-     * @param string $name
+     * @param  string  $name
      * @param $value
      * @return void
      */

--- a/src/Data/SerializedModel.php
+++ b/src/Data/SerializedModel.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sammyjo20\LaravelHaystack\Data;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Database\Eloquent\Model;
 
 class SerializedModel
 {

--- a/src/Data/SerializedModel.php
+++ b/src/Data/SerializedModel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sammyjo20\LaravelHaystack\Data;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+
+class SerializedModel
+{
+    use SerializesModels;
+
+    public function __construct(public Model $model)
+    {
+        //
+    }
+}

--- a/src/Exceptions/HaystackModelExists.php
+++ b/src/Exceptions/HaystackModelExists.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sammyjo20\LaravelHaystack\Exceptions;
+
+use Exception;
+use Illuminate\Support\Str;
+
+class HaystackModelExists extends Exception
+{
+    /**
+     * Constructor
+     *
+     * @param string $key
+     */
+    public function __construct(string $key)
+    {
+        $key = Str::remove('model:', $key);
+
+        parent::__construct(sprintf('Model with the key "%s" has already been defined on the Haystack. Use the second argument to define a custom key.', $key));
+    }
+}

--- a/src/Exceptions/HaystackModelExists.php
+++ b/src/Exceptions/HaystackModelExists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sammyjo20\LaravelHaystack\Exceptions;
 
 use Exception;
@@ -10,7 +12,7 @@ class HaystackModelExists extends Exception
     /**
      * Constructor
      *
-     * @param string $key
+     * @param  string  $key
      */
     public function __construct(string $key)
     {

--- a/src/Models/Haystack.php
+++ b/src/Models/Haystack.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Sammyjo20\LaravelHaystack\Models;
 
-use Carbon\CarbonImmutable;
 use Closure;
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Prunable;
 use Sammyjo20\LaravelHaystack\Casts\Serialized;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Concerns\ManagesBales;
 use Sammyjo20\LaravelHaystack\Casts\SerializeClosure;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Sammyjo20\LaravelHaystack\Builders\HaystackBuilder;
-use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Database\Factories\HaystackFactory;
 
 /**

--- a/src/Models/Haystack.php
+++ b/src/Models/Haystack.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sammyjo20\LaravelHaystack\Models;
 
 use Carbon\CarbonImmutable;
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Prunable;
@@ -14,8 +15,17 @@ use Sammyjo20\LaravelHaystack\Concerns\ManagesBales;
 use Sammyjo20\LaravelHaystack\Casts\SerializeClosure;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Sammyjo20\LaravelHaystack\Builders\HaystackBuilder;
+use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Database\Factories\HaystackFactory;
 
+/**
+ * @property Closure $on_then
+ * @property Closure $on_catch
+ * @property Closure $on_finally
+ * @property Closure $on_paused
+ * @property Closure $middleware
+ * @property HaystackOptions $options
+ */
 class Haystack extends Model
 {
     use HasFactory;

--- a/tests/Feature/HaystackBuilderTest.php
+++ b/tests/Feature/HaystackBuilderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Queue;
-use Sammyjo20\LaravelHaystack\Exceptions\HaystackModelExists;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Models\HaystackBale;
 use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
@@ -13,6 +12,7 @@ use Sammyjo20\LaravelHaystack\Middleware\CheckFinished;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\NameJob;
 use Sammyjo20\LaravelHaystack\Middleware\IncrementAttempts;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CacheJob;
+use Sammyjo20\LaravelHaystack\Exceptions\HaystackModelExists;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Callables\Middleware;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Models\CountrySinger;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CountrySingerJob;

--- a/tests/Feature/HaystackBuilderTest.php
+++ b/tests/Feature/HaystackBuilderTest.php
@@ -323,3 +323,17 @@ test('it will throw an exception if you try to define two models without specify
         ->withModel($countrySingerB)
         ->dispatch();
 });
+
+test('you can specify a custom option or overwrite an existing option on the haystack', function () {
+    $haystack = Haystack::build()
+        ->setOption('yeeHaw', '🤠')
+        ->setOption('returnDataOnFinish', false)
+        ->create();
+
+    $options = $haystack->options;
+
+    expect($options)->toBeInstanceOf(HaystackOptions::class);
+    expect($options->yeeHaw)->toEqual('🤠');
+    expect($options->returnDataOnFinish)->toBeFalse();
+    expect($options->allowFailures)->toBeFalse();
+});

--- a/tests/Feature/HaystackBuilderTest.php
+++ b/tests/Feature/HaystackBuilderTest.php
@@ -255,3 +255,17 @@ test('you can allow failures on the haystack', function () {
     expect($options)->toBeInstanceOf(HaystackOptions::class);
     expect($options->allowFailures)->toBeTrue();
 });
+
+test('you can use the beforeSave method to run additional logic on the haystack model before it is saved', function () {
+    $haystack = Haystack::build()
+        ->addJob(new NameJob('Sam'))
+        ->addJob(new NameJob('Gareth'))
+        ->beforeSave(function (Haystack $haystack) {
+            $haystack->options->yeeHaw = true;
+        })
+        ->create();
+
+    $haystack->refresh();
+
+    expect($haystack->options)->toHaveKey('yeeHaw', true);
+});

--- a/tests/Feature/HaystackBuilderTest.php
+++ b/tests/Feature/HaystackBuilderTest.php
@@ -281,21 +281,10 @@ test('you can provide a model to be shared across the whole haystack', function 
 
     $countrySinger = CountrySinger::create(['name' => 'Kelsea Ballerini'])->fresh();
 
-    $haystack = Haystack::build()
+    Haystack::build()
         ->addJob(new CountrySingerJob)
         ->withModel('singer', $countrySinger)
         ->dispatch();
 
     expect(cache()->get('singer'))->toEqual('Kelsea Ballerini');
-
-    // Let's also make sure the data does not include the model by default
-
-    $data = $haystack->allData();
-
-    expect($data)->toHaveCount(0);
-
-    $data = $haystack->allData(true);
-
-    expect($data)->toHaveCount(1);
-    expect($data['model:singer'])->toEqual($countrySinger);
 });

--- a/tests/Feature/HaystackBuilderTest.php
+++ b/tests/Feature/HaystackBuilderTest.php
@@ -3,20 +3,19 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Models\HaystackBale;
 use Sammyjo20\LaravelHaystack\Data\HaystackOptions;
 use Sammyjo20\LaravelHaystack\Middleware\CheckAttempts;
 use Sammyjo20\LaravelHaystack\Middleware\CheckFinished;
-use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CountrySingerJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\NameJob;
 use Sammyjo20\LaravelHaystack\Middleware\IncrementAttempts;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CacheJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Callables\Middleware;
-use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\OrderCheckCacheJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Models\CountrySinger;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CountrySingerJob;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\OrderCheckCacheJob;
 
 test('a haystack can be created with jobs', function () {
     $haystack = Haystack::build()

--- a/tests/Feature/StackableJobTest.php
+++ b/tests/Feature/StackableJobTest.php
@@ -6,16 +6,15 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CustomOptionJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\FailJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CacheJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\ExcitedJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\SetDataJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\AutoCacheJob;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CustomOptionJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\AppendingDelayJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\GetAndCacheDataJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\GetAllAndCacheDataJob;
-use function Symfony\Component\Translation\t;
 
 test('a stackable job can call the next job', function () {
     $haystack = Haystack::build()

--- a/tests/Feature/StackableJobTest.php
+++ b/tests/Feature/StackableJobTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CustomOptionJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\FailJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CacheJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\ExcitedJob;
@@ -14,6 +15,7 @@ use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\AutoCacheJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\AppendingDelayJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\GetAndCacheDataJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\GetAllAndCacheDataJob;
+use function Symfony\Component\Translation\t;
 
 test('a stackable job can call the next job', function () {
     $haystack = Haystack::build()
@@ -120,4 +122,14 @@ test('a stackable job can be dispatched without being on a haystack', function (
     AutoCacheJob::dispatch('name', 'Sammy');
 
     expect(cache()->get('name'))->toEqual('Sammy');
+});
+
+test('you can get a haystack option from the stackable job', function () {
+    $haystack = Haystack::build()
+        ->addJob(new CustomOptionJob('yeeHaw'))
+        ->setOption('yeeHaw', '🤠')
+        ->dispatch();
+
+    expect(cache()->get('option'))->toEqual('🤠');
+    expect(cache()->get('allOptions'))->toEqual($haystack->options);
 });

--- a/tests/Fixtures/Jobs/CountrySingerJob.php
+++ b/tests/Fixtures/Jobs/CountrySingerJob.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Sammyjo20\LaravelHaystack\Concerns\Stackable;
+use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
+use Sammyjo20\LaravelHaystack\Tests\Exceptions\StackableException;
+
+class CountrySingerJob implements ShouldQueue, StackableJob
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Stackable;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     *
+     * @throws StackableException
+     */
+    public function handle()
+    {
+        $model = $this->getHaystackModel('singer');
+
+        cache()->put('singer', $model->name);
+
+        $this->nextJob();
+    }
+}

--- a/tests/Fixtures/Jobs/CountrySingerJob.php
+++ b/tests/Fixtures/Jobs/CountrySingerJob.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Sammyjo20\LaravelHaystack\Concerns\Stackable;
 use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
 use Sammyjo20\LaravelHaystack\Tests\Exceptions\StackableException;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Models\CountrySinger;
 
 class CountrySingerJob implements ShouldQueue, StackableJob
 {
@@ -22,7 +23,7 @@ class CountrySingerJob implements ShouldQueue, StackableJob
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(public string $key)
     {
         //
     }
@@ -36,7 +37,7 @@ class CountrySingerJob implements ShouldQueue, StackableJob
      */
     public function handle()
     {
-        $model = $this->getHaystackModel('singer');
+        $model = $this->getHaystackModel($this->key);
 
         cache()->put('singer', $model->name);
 

--- a/tests/Fixtures/Jobs/CountrySingerJob.php
+++ b/tests/Fixtures/Jobs/CountrySingerJob.php
@@ -12,7 +12,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Sammyjo20\LaravelHaystack\Concerns\Stackable;
 use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
 use Sammyjo20\LaravelHaystack\Tests\Exceptions\StackableException;
-use Sammyjo20\LaravelHaystack\Tests\Fixtures\Models\CountrySinger;
 
 class CountrySingerJob implements ShouldQueue, StackableJob
 {

--- a/tests/Fixtures/Jobs/CustomOptionJob.php
+++ b/tests/Fixtures/Jobs/CustomOptionJob.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Sammyjo20\LaravelHaystack\Concerns\Stackable;
+use Sammyjo20\LaravelHaystack\Contracts\StackableJob;
+use Sammyjo20\LaravelHaystack\Tests\Exceptions\StackableException;
+
+class CustomOptionJob implements ShouldQueue, StackableJob
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Stackable;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(public string $option)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     *
+     * @throws StackableException
+     */
+    public function handle()
+    {
+        cache()->put('option', $this->getHaystackOption($this->option));
+        cache()->put('allOptions', $this->getHaystackOptions());
+
+        $this->nextBale(); // Alias of next job
+    }
+}

--- a/tests/Fixtures/Models/CountrySinger.php
+++ b/tests/Fixtures/Models/CountrySinger.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Sammyjo20\LaravelHaystack\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CountrySinger extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+}

--- a/tests/Fixtures/Models/CountrySinger.php
+++ b/tests/Fixtures/Models/CountrySinger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sammyjo20\LaravelHaystack\Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Migrations/create_country_singers_table.php
+++ b/tests/Migrations/create_country_singers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('country_singers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('country_singers');
+    }
+};

--- a/tests/Unit/HaystackDataTest.php
+++ b/tests/Unit/HaystackDataTest.php
@@ -58,5 +58,5 @@ test('models stored in haystack data wont be returned when retrieving all data',
     $data = $haystack->allData(true);
 
     expect($data)->toHaveCount(1);
-    expect($data['model:' . CountrySinger::class])->toEqual($countrySinger->fresh());
+    expect($data['model:'.CountrySinger::class])->toEqual($countrySinger->fresh());
 });

--- a/tests/Unit/HaystackDataTest.php
+++ b/tests/Unit/HaystackDataTest.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Models\HaystackData;
+use Sammyjo20\LaravelHaystack\Tests\Fixtures\Models\CountrySinger;
 
 test('a haystack data row can belong to a haystack', function () {
     $haystack = Haystack::factory()->create();
@@ -30,4 +33,31 @@ test('a haystack data row can cast the data when retrieving', function () {
 
     expect($haystackData->value)->toBeInstanceOf(Collection::class);
     expect($haystackData->value)->toEqual(new Collection(['name' => 'Sam', 'age' => 22]));
+});
+
+test('models stored in haystack data wont be returned when retrieving all data', function () {
+    $migration = include __DIR__.'/../Migrations/create_country_singers_table.php';
+    $migration->up();
+
+    $countrySinger = CountrySinger::create(['name' => 'Kenny Rogers']);
+
+    $haystack = Haystack::build()
+        ->withModel('singer', $countrySinger)
+        ->create();
+
+    $haystackData = $haystack->data()->sole();
+
+    expect($haystackData->value)->toBeInstanceOf(Model::class);
+    expect($haystackData->value)->toEqual($countrySinger->fresh());
+
+    // Let's also make sure the data does not include the model by default
+
+    $data = $haystack->allData();
+
+    expect($data)->toHaveCount(0);
+
+    $data = $haystack->allData(true);
+
+    expect($data)->toHaveCount(1);
+    expect($data['model:singer'])->toEqual($countrySinger->fresh());
 });

--- a/tests/Unit/HaystackDataTest.php
+++ b/tests/Unit/HaystackDataTest.php
@@ -41,7 +41,7 @@ test('models stored in haystack data wont be returned when retrieving all data',
     $countrySinger = CountrySinger::create(['name' => 'Kenny Rogers']);
 
     $haystack = Haystack::build()
-        ->withModel('singer', $countrySinger)
+        ->withModel($countrySinger)
         ->create();
 
     $haystackData = $haystack->data()->sole();
@@ -58,5 +58,5 @@ test('models stored in haystack data wont be returned when retrieving all data',
     $data = $haystack->allData(true);
 
     expect($data)->toHaveCount(1);
-    expect($data['model:singer'])->toEqual($countrySinger->fresh());
+    expect($data['model:' . CountrySinger::class])->toEqual($countrySinger->fresh());
 });

--- a/tests/Unit/HaystackDataTest.php
+++ b/tests/Unit/HaystackDataTest.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Sammyjo20\LaravelHaystack\Casts\SerializedModel;
+use Illuminate\Database\Eloquent\Model;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Models\HaystackData;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Models\CountrySinger;


### PR DESCRIPTION
🚀 This PR introduces a handy helper method to define models that should be accessible to every job within the Haystack. Internally, it will serialize the model including its relationships and scopes and you will be able to retrieve the model in your code.

```php
Haystack::build()
    ->addJob(new RecordPodcast)
    ->withModel($user)
    ->dispatch();
```

Inside your jobs...

```php
$this->getHaystackModel(User::class);
```

This PR also introduces a `beforeSave` callback which is useful if you want to modify the Haystack model before it is created and dispatched.

```php
Haystack::build()
    ->addJob(new RecordPodcast)
    ->beforeSave(function (Haystack $haystack) {
             $haystack->options->customOption = true;
     })
    ->dispatch();
```

This PR also introduces a new ability to set a custom option that you can use across your Haystack.

```php
Haystack::build()
    ->addJob(new RecordPodcast)
    ->setOption('yeeHaw', '🤠')
    ->dispatch();
```

Inside your jobs...

```php
$this->getHaystackOptions();

$this->getHaystackOption('yeeHaw');
```