### PR TITLE
Fix | Removed Spatie Laravel Package Tools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         php: [8.1]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: run-tests
 
 on:
   push:
@@ -9,41 +9,43 @@ on:
       - '*'
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1 ]
-        laravel: [ ^8.0, ^9.0 ]
-        dependency-version: [ prefer-stable ]
+        os: [ubuntu-latest]
+        php: [8.1]
+        laravel: [8.*, 9.*]
+        stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: ^8.0
-            testbench: ^6.0
-          - laravel: ^9.0
-            testbench: ^7.0
+          - laravel: 8.*
+            testbench: ^6.24
+          - laravel: 9.*
+            testbench: 7.*
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Install composer dependencies
+      - name: Setup problem matchers
         run: |
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: composer test
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,7 @@
         "illuminate/database": "^8.0 || ^9.0",
         "illuminate/queue": "^8.0 || ^9.0",
         "illuminate/support": "^8.0 || ^9.0",
-        "laravel/serializable-closure": "^1.2",
-        "sammyjo20/laravel-chunkable-jobs": "^0.1.1",
-        "spatie/laravel-package-tools": "^1.13.5"
+        "laravel/serializable-closure": "^1.2"
     },
     "require-dev": {
         "jessarcher/laravel-castable-data-transfer-object": "^2.2",
@@ -32,6 +30,7 @@
         "orchestra/testbench": "^7.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.2",
+        "sammyjo20/laravel-chunkable-jobs": "^0.2.0",
         "spatie/laravel-ray": "^1.26"
     },
     "minimum-stability": "stable",
@@ -69,5 +68,8 @@
         "test": [
             "./vendor/bin/pest"
         ]
+    },
+    "suggest": {
+        "sammyjo20/laravel-chunkable-jobs": "Allows you to use the job chunking feature"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "jessarcher/laravel-castable-data-transfer-object": "^2.2",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^6.24|^7.8",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.2",
         "sammyjo20/laravel-chunkable-jobs": "^0.2.0",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Sammyjo20\\LaravelHaystack\\LaravelHaystackServiceProvider"
+                "Sammyjo20\\LaravelHaystack\\HaystackServiceProvider"
             ]
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
         "sammyjo20/laravel-chunkable-jobs": "^0.2.0",
         "spatie/laravel-ray": "^1.26"
     },
+    "suggest": {
+        "sammyjo20/laravel-chunkable-jobs": "Allows you to use the job chunking feature"
+    },
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
@@ -68,8 +71,5 @@
         "test": [
             "./vendor/bin/pest"
         ]
-    },
-    "suggest": {
-        "sammyjo20/laravel-chunkable-jobs": "Allows you to use the job chunking feature"
     }
 }

--- a/src/ChunkableHaystackJob.php
+++ b/src/ChunkableHaystackJob.php
@@ -17,7 +17,7 @@ abstract class ChunkableHaystackJob extends ChunkableJob implements StackableJob
      *
      * @var array|string[]
      */
-    protected array $extraUnsetProperties = [
+    protected array $ignoredProperties = [
         'haystack', 'haystackBaleId', 'haystackBaleAttempts',
     ];
 

--- a/src/Console/Commands/HaystackInstall.php
+++ b/src/Console/Commands/HaystackInstall.php
@@ -25,21 +25,41 @@ class HaystackInstall extends Command
      */
     public function handle(): int
     {
-        $this->info('Publishing migrations...');
+        $this->info(' 🚀 | Installing Haystack');
 
-        $this->call('vendor:publish', ['--tag' => 'haystack-migrations']);
+        $this->info(' 🪐 | Publishing migrations...');
 
-        $this->info('Publishing config...');
+        $this->callSilently('vendor:publish', ['--tag' => 'haystack-migrations']);
 
-        $this->call('vendor:publish', ['--tag' => 'haystack-config']);
+        $this->info(' 🔭 | Publishing config...');
+
+        $this->callSilently('vendor:publish', ['--tag' => 'haystack-config']);
 
         $runMigrations = $this->confirm('Would you like to run migrations?', false);
 
         if ($runMigrations) {
-            $this->call('migrate');
-        }g
+            $this->callSilently('migrate');
 
-        // Todo: Add star on Github?
+            $this->info(' 🎯 | Migrations run successfully');
+        }
+
+        if ($this->confirm(' 🤩 | Would you like to star the repo on GitHub?')) {
+            $repoUrl = 'https://github.com/sammyjo20/laravel-haystack';
+
+            if (PHP_OS_FAMILY == 'Darwin') {
+                exec("open {$repoUrl}");
+            }
+
+            if (PHP_OS_FAMILY == 'Windows') {
+                exec("start {$repoUrl}");
+            }
+
+            if (PHP_OS_FAMILY == 'Linux') {
+                exec("xdg-open {$repoUrl}");
+            }
+        }
+
+        $this->info(' ✅ | Haystack has been installed. Thank you for using Haystack. Happy developing! ❤️');
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/HaystackInstall.php
+++ b/src/Console/Commands/HaystackInstall.php
@@ -25,15 +25,21 @@ class HaystackInstall extends Command
      */
     public function handle(): int
     {
-        $this->call('vendor:publish --tag=haystack-config');
+        $this->info('Publishing migrations...');
 
-        $this->call('vendor:publish --tag=haystack-migrations');
+        $this->call('vendor:publish', ['--tag' => 'haystack-migrations']);
+
+        $this->info('Publishing config...');
+
+        $this->call('vendor:publish', ['--tag' => 'haystack-config']);
 
         $runMigrations = $this->confirm('Would you like to run migrations?', false);
 
         if ($runMigrations) {
             $this->call('migrate');
-        }
+        }g
+
+        // Todo: Add star on Github?
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/HaystackInstall.php
+++ b/src/Console/Commands/HaystackInstall.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sammyjo20\LaravelHaystack\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class HaystackInstall extends Command
+{
+    /**
+     * @var string
+     */
+    public $signature = 'haystack:install';
+
+    /**
+     * @var string
+     */
+    public $description = 'Install Laravel Haystack';
+
+    /**
+     * Install Haystack
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $this->call('vendor:publish --tag=haystack-config');
+
+        $this->call('vendor:publish --tag=haystack-migrations');
+
+        $runMigrations = $this->confirm('Would you like to run migrations?', false);
+
+        if ($runMigrations) {
+            $this->call('migrate');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/HaystacksResume.php
+++ b/src/Console/Commands/HaystacksResume.php
@@ -7,7 +7,7 @@ namespace Sammyjo20\LaravelHaystack\Console\Commands;
 use Illuminate\Console\Command;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 
-class ResumeHaystacks extends Command
+class HaystacksResume extends Command
 {
     public $signature = 'haystacks:resume';
 

--- a/src/HaystackServiceProvider.php
+++ b/src/HaystackServiceProvider.php
@@ -8,11 +8,12 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Events\JobProcessed;
+use Sammyjo20\LaravelHaystack\Console\Commands\HaystackInstall;
 use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksClear;
 use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksForget;
 use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksResume;
 
-class LaravelHaystackServiceProvider extends ServiceProvider
+class HaystackServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
@@ -51,7 +52,9 @@ class LaravelHaystackServiceProvider extends ServiceProvider
         ], 'haystack-config');
 
         $this->publishes([
-            __DIR__.'/../database/migrations/' => database_path('migrations'),
+            __DIR__ . '/../database/migrations/create_haystacks_table.php.stub' => database_path('migrations/' . now()->format('Y_m_d_His') . '_create_haystacks_table.php'),
+            __DIR__ . '/../database/migrations/create_haystack_bales_table.php.stub' => database_path('migrations/' . now()->addSeconds(1)->format('Y_m_d_His') . '_create_haystack_bales_table.php'),
+            __DIR__ . '/../database/migrations/create_haystack_data_table.php.stub' => database_path('migrations/' . now()->addSeconds(2)->format('Y_m_d_His') . '_create_haystack_data_table.php'),
         ], 'haystack-migrations');
 
         return $this;
@@ -72,6 +75,7 @@ class LaravelHaystackServiceProvider extends ServiceProvider
             HaystacksClear::class,
             HaystacksForget::class,
             HaystacksResume::class,
+            HaystackInstall::class,
         ]);
 
         return $this;

--- a/src/HaystackServiceProvider.php
+++ b/src/HaystackServiceProvider.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Events\JobProcessed;
-use Sammyjo20\LaravelHaystack\Console\Commands\HaystackInstall;
 use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksClear;
+use Sammyjo20\LaravelHaystack\Console\Commands\HaystackInstall;
 use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksForget;
 use Sammyjo20\LaravelHaystack\Console\Commands\HaystacksResume;
 
@@ -52,9 +52,9 @@ class HaystackServiceProvider extends ServiceProvider
         ], 'haystack-config');
 
         $this->publishes([
-            __DIR__ . '/../database/migrations/create_haystacks_table.php.stub' => database_path('migrations/' . now()->format('Y_m_d_His') . '_create_haystacks_table.php'),
-            __DIR__ . '/../database/migrations/create_haystack_bales_table.php.stub' => database_path('migrations/' . now()->addSeconds(1)->format('Y_m_d_His') . '_create_haystack_bales_table.php'),
-            __DIR__ . '/../database/migrations/create_haystack_data_table.php.stub' => database_path('migrations/' . now()->addSeconds(2)->format('Y_m_d_His') . '_create_haystack_data_table.php'),
+            __DIR__.'/../database/migrations/create_haystacks_table.php.stub' => database_path('migrations/'.now()->format('Y_m_d_His').'_create_haystacks_table.php'),
+            __DIR__.'/../database/migrations/create_haystack_bales_table.php.stub' => database_path('migrations/'.now()->addSeconds(1)->format('Y_m_d_His').'_create_haystack_bales_table.php'),
+            __DIR__.'/../database/migrations/create_haystack_data_table.php.stub' => database_path('migrations/'.now()->addSeconds(2)->format('Y_m_d_His').'_create_haystack_data_table.php'),
         ], 'haystack-migrations');
 
         return $this;

--- a/tests/Feature/AutomaticProcessingTest.php
+++ b/tests/Feature/AutomaticProcessingTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CacheJob;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\ReleaseJob;

--- a/tests/Feature/AutomaticProcessingTest.php
+++ b/tests/Feature/AutomaticProcessingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Sammyjo20\LaravelHaystack\Tests\Fixtures\Jobs\CacheJob;
@@ -35,7 +36,7 @@ test('it can process jobs automatically', function () {
 });
 
 test('if a job is released it will not be processed', function () {
-    Queue::fake([
+    Bus::fake([
         ReleaseJob::class,
     ]);
 
@@ -50,7 +51,7 @@ test('if a job is released it will not be processed', function () {
     expect(cache()->get('friend'))->toEqual('Michael');
     expect(cache()->get('boss'))->toBeNull();
 
-    Queue::assertPushed(ReleaseJob::class);
+    Bus::assertDispatched(ReleaseJob::class);
 
     // We'll make sure that Gareth's job is still queued.
 

--- a/tests/Feature/StackableJobTest.php
+++ b/tests/Feature/StackableJobTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -69,7 +70,7 @@ test('when a stackable job is created the haystack is loaded', function () {
 });
 
 test('you can dispatch the next job in the haystack with a custom delay', function () {
-    Queue::fake([
+    Bus::fake([
         CacheJob::class,
     ]);
 
@@ -77,7 +78,7 @@ test('you can dispatch the next job in the haystack with a custom delay', functi
         ->addJob(new AppendingDelayJob)
         ->dispatch();
 
-    Queue::assertPushed(CacheJob::class, function (CacheJob $job) {
+    Bus::assertDispatched(CacheJob::class, function (CacheJob $job) {
         return $job->delay === 120 && $job->queue === 'cowboy' && $job->connection === 'redis';
     });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,7 +16,7 @@ function withAutomaticProcessing(): void
     // It's a bit hacky, but we'll run the "bootingPackage" method
     // on the provider to start recording events.
 
-    (new LaravelHaystackServiceProvider(app()))->bootingPackage();
+    (new LaravelHaystackServiceProvider(app()))->registerQueueListeners();
 }
 
 function dontDeleteHaystack(): void

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Sammyjo20\LaravelHaystack\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Sammyjo20\LaravelHaystack\LaravelHaystackServiceProvider;
+use Sammyjo20\LaravelHaystack\HaystackServiceProvider;
 
 uses(TestCase::class)->in(__DIR__);
 uses(RefreshDatabase::class)->in(__DIR__);
@@ -16,7 +16,7 @@ function withAutomaticProcessing(): void
     // It's a bit hacky, but we'll run the "bootingPackage" method
     // on the provider to start recording events.
 
-    (new LaravelHaystackServiceProvider(app()))->registerQueueListeners();
+    (new HaystackServiceProvider(app()))->registerQueueListeners();
 }
 
 function dontDeleteHaystack(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ namespace Sammyjo20\LaravelHaystack\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Sammyjo20\LaravelHaystack\LaravelHaystackServiceProvider;
+use Sammyjo20\LaravelHaystack\HaystackServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -22,7 +22,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            LaravelHaystackServiceProvider::class,
+            HaystackServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
I have decided to drop a dependency and remove the Spatie Laravel Package Tools package. I have also removed the `laravel-chunkable-jobs` package as I've decided people can opt-in instead of forcing people to use it even if they don't use Chunkable jobs.