### PR TITLE
Support different db connection

### DIFF
--- a/config/haystack.php
+++ b/config/haystack.php
@@ -71,4 +71,15 @@ return [
 
     'keep_finished_haystacks_for_days' => 1,
 
+     /*
+    |--------------------------------------------------------------------------
+    | Default Database Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which database connectionsyou wish
+    | to use to store haystack jobs .
+    |
+    */
+
+    'db_connection' => env('DB_CONNECTION'),
 ];

--- a/src/Models/Haystack.php
+++ b/src/Models/Haystack.php
@@ -128,4 +128,14 @@ class Haystack extends Model
     {
         return $this->finished_at instanceof CarbonImmutable;
     }
+
+     /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('haystack.db_connection');
+    }
 }

--- a/src/Models/HaystackBale.php
+++ b/src/Models/HaystackBale.php
@@ -71,4 +71,14 @@ class HaystackBale extends Model
 
         return $job;
     }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('haystack.db_connection');
+    }
 }

--- a/src/Models/HaystackData.php
+++ b/src/Models/HaystackData.php
@@ -72,4 +72,14 @@ class HaystackData extends Model
 
         return $this->castAttribute('value', $value);
     }
+
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName()
+    {
+        return config('haystack.db_connection');
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,7 @@ class TestCase extends Orchestra
 
     public function getEnvironmentSetUp($app)
     {
-        config()->set('database.default', 'testing');
+        config()->set('haystack.db_connection', 'testing');
         config()->set('database.connections.testing.foreign_key_constraints', true);
         config()->set('haystack.process_automatically', false);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,6 +34,7 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('haystack.db_connection', 'testing');
+        config()->set('database.default', 'testing');
         config()->set('database.connections.testing.foreign_key_constraints', true);
         config()->set('haystack.process_automatically', false);
 


### PR DESCRIPTION
in this PR

- i have added a new config called db_connection 


as I found sometimes haystack tables can be on different db connection due to the high volume of pushed records ... for example singlestore