### PR TITLE
Tiny code doc alignment fix

### DIFF
--- a/config/haystack.php
+++ b/config/haystack.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 return [
 
     /*
-   |--------------------------------------------------------------------------
-   | Return All Haystack Data When Finished
-   |--------------------------------------------------------------------------
-   |
-   | This value if set to true, will instruct Haystack to query all the
-   | haystack data rows out of the database and return them to the
-   | then/finally/catch blocks as a collection.
-   |
-   */
+    |--------------------------------------------------------------------------
+    | Return All Haystack Data When Finished
+    |--------------------------------------------------------------------------
+    |
+    | This value if set to true, will instruct Haystack to query all the
+    | haystack data rows out of the database and return them to the
+    | then/finally/catch blocks as a collection.
+    |
+    */
 
     'return_all_haystack_data_when_finished' => true,
 


### PR DESCRIPTION
This PR fixes the alignment of the first code doc in the publishable configuration file. All the other code docs have 4 spaces, while the first has 3.

Thanks again for your work on this project! ❤️ 