### PR TITLE
Add initial resume_at date support to HaystackBuilder

### DIFF
--- a/src/Builders/HaystackBuilder.php
+++ b/src/Builders/HaystackBuilder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Sammyjo20\LaravelHaystack\Builders;
 
 use Closure;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -51,6 +53,11 @@ class HaystackBuilder
      * Global delay
      */
     public int $globalDelayInSeconds = 0;
+
+    /**
+     * Initial resumeAt time
+     */
+    public ?CarbonImmutable $resumeAt = null;
 
     /**
      * Callbacks that will be run at various events
@@ -267,6 +274,17 @@ class HaystackBuilder
         return $this;
     }
 
+    public function pausedUntil(DateTimeInterface $resumeAt): static
+    {
+        if (! $resumeAt instanceof CarbonImmutable) {
+            $resumeAt = Carbon::parse($resumeAt)->toImmutable();
+        }
+
+        $this->resumeAt = $resumeAt;
+
+        return $this;
+    }
+
     /**
      * Set a global queue for the jobs.
      *
@@ -417,6 +435,7 @@ class HaystackBuilder
         $haystack->callbacks = $this->callbacks->toSerializable();
         $haystack->middleware = $this->middleware->toSerializable();
         $haystack->options = $this->options;
+        $haystack->resume_at = $this->resumeAt;
 
         if ($this->beforeSave instanceof Closure) {
             $haystack = tap($haystack, $this->beforeSave);

--- a/tests/Feature/HaystackBuilderTest.php
+++ b/tests/Feature/HaystackBuilderTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Queue;
 use Sammyjo20\LaravelHaystack\Models\Haystack;
@@ -67,6 +68,23 @@ test('a haystack can be created with default delay, queue and connection', funct
     expect($haystackBales[0]->delay)->toEqual(60);
     expect($haystackBales[0]->on_queue)->toEqual('testing');
     expect($haystackBales[0]->on_connection)->toEqual('database');
+});
+
+test('a haystack can be created with initial resume_at', function () {
+    $pauseUntil = now()->addMinutes(5)->toImmutable();
+
+    $haystack = Haystack::build()
+        ->addJob(new NameJob('Sam'))
+        ->pausedUntil($pauseUntil)
+        ->create();
+
+    expect($haystack)->toBeInstanceOf(Haystack::class);
+    expect($haystack->resume_at)->toBeInstanceOf(CarbonImmutable::class);
+    expect($haystack->resume_at->toIso8601String())->toEqual($pauseUntil->toIso8601String());
+
+    $haystackBales = $haystack->bales()->get();
+
+    expect($haystackBales)->toHaveCount(1);
 });
 
 test('a haystack can be created with middleware', function () {


### PR DESCRIPTION
Added a new method `pausedUntil()` that allows setting an initial `resume_at` date when building a Haystack. This can be used to set a longer initial delay if you are using Amazon SQS (which has a max delay of 15 minutes)

```php
use Sammyjo20\LaravelHaystack\Models\Haystack;

// ...

Haystack::build()
        ->addJob(new NameJob('Sam'))
        ->pausedUntil(now()->addDays(5))
        ->dispatch();
```